### PR TITLE
Restart bobcat-validator service when config changes through puppet

### DIFF
--- a/manifests/validator.pp
+++ b/manifests/validator.pp
@@ -55,7 +55,8 @@ class bobcat::validator (
       owner   => 'root',
       group   => 'root',
       mode    => '0444',
-      content => epp($config_template);
+      content => epp($config_template),
+      notify  => Service['bobcat-validator'];
 
     '/etc/systemd/system/bobcat-dynconf.timer':
       ensure  => file,


### PR DESCRIPTION
When the /etc/bobcat/validator.yaml config file changes the service needs to be restarted.